### PR TITLE
Парсер Shortcut

### DIFF
--- a/grammar/Common.g4
+++ b/grammar/Common.g4
@@ -50,8 +50,8 @@ shortcut
 :
     BLOCK_START
         NUMBER // 0
-        VS NUMBER // Клавиша
-        VS NUMBER // маска (0x4, - Shift, 0x8 - Ctrl, 0x10 - Alt)
+        VS Key = NUMBER // Клавиша
+        VS Modifier = NUMBER // маска (0x4, - Shift, 0x8 - Ctrl, 0x10 - Alt)
     BLOCK_END
 ;
 

--- a/src/OFP.Abstractions/ObjectModel/Platform/Shortcut.cs
+++ b/src/OFP.Abstractions/ObjectModel/Platform/Shortcut.cs
@@ -3,7 +3,7 @@ namespace OFP.ObjectModel.Platform
     /// <summary>
     /// СочетаниеКлавиш.
     /// </summary>
-    public struct Shortcut
+    public readonly struct Shortcut
     {
         /// <summary>
         /// Alt, Ctrl, Shift.

--- a/src/OFP.Abstractions/ObjectModel/Platform/Shortcut.cs
+++ b/src/OFP.Abstractions/ObjectModel/Platform/Shortcut.cs
@@ -1,9 +1,11 @@
+using System;
+
 namespace OFP.ObjectModel.Platform
 {
     /// <summary>
     /// СочетаниеКлавиш.
     /// </summary>
-    public readonly struct Shortcut
+    public readonly struct Shortcut : IEquatable<Shortcut>
     {
         /// <summary>
         /// Alt, Ctrl, Shift.
@@ -20,7 +22,42 @@ namespace OFP.ObjectModel.Platform
             (Key, Modifiers) = (key, modifiers);
         }
 
+        #region Object
+
         public override string ToString() =>
             $"{nameof(Shortcut)}: {Modifiers}+{Key}";
+
+        public override int GetHashCode() =>
+            (Key, Modifiers).GetHashCode();
+
+        public override bool Equals(object obj)
+        {
+            var result = obj switch
+            {
+                Shortcut shortcut => Equals(in shortcut),
+                _ => false,
+            };
+
+            return result;
+        }
+
+        #endregion
+
+        #region IEquatable
+
+        public bool Equals(Shortcut other) => Equals(in other);
+
+        #endregion
+
+        private bool Equals(in Shortcut other)
+        {
+            return Key == other.Key && Modifiers == other.Modifiers;
+        }
+
+        public static bool operator ==(in Shortcut left, in Shortcut right) =>
+            left.Equals(right);
+
+        public static bool operator !=(in Shortcut left, in Shortcut right) =>
+            !left.Equals(right);
     }
 }

--- a/src/OFP.Abstractions/ObjectModel/Platform/Shortcut.cs
+++ b/src/OFP.Abstractions/ObjectModel/Platform/Shortcut.cs
@@ -19,5 +19,8 @@ namespace OFP.ObjectModel.Platform
         {
             (Key, Modifiers) = (key, modifiers);
         }
+
+        public override string ToString() =>
+            $"{nameof(Shortcut)}: {Modifiers}+{Key}";
     }
 }

--- a/src/OFP.Library.Tests/ObjectModelTests/ShortcutTests.cs
+++ b/src/OFP.Library.Tests/ObjectModelTests/ShortcutTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using OFP.ObjectModel.Platform;
+
+namespace OFP.Library.Tests.ObjectModelTests
+{
+    /// <summary>
+    /// Тесты на <see cref="Shortcut"/>.
+    /// </summary>
+    [TestFixture]
+    public class ShortcutTests
+    {
+        private static IEnumerable<TestCaseData> GetEqualValues()
+        {
+            var left = new Shortcut(Key.M, KeyModifier.Alt);
+            var right = new Shortcut(Key.M, KeyModifier.Alt);
+
+            yield return
+                new TestCaseData(left, right);
+
+            left = new Shortcut(Key.BackSpace, KeyModifier.None);
+            right = new Shortcut(Key.BackSpace, KeyModifier.None);
+
+            yield return
+                new TestCaseData(left, right);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(GetEqualValues))]
+        public void Shortcut_Equals_ChecksEquality(object left, object right)
+        {
+            var result = left.Equals(right);
+
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        [TestCaseSource(nameof(GetEqualValues))]
+        public void Shortcut_OpEquality_ChecksEquality(Shortcut left, Shortcut right)
+        {
+            var result = left == right;
+
+            result.Should().BeTrue();
+        }
+
+        private static IEnumerable<TestCaseData> GetUnequalValues()
+        {
+            var left = new Shortcut(Key.A, KeyModifier.None);
+            var right = new Shortcut(Key.A, KeyModifier.Alt);
+
+            yield return
+                new TestCaseData(left, right);
+
+            left = new Shortcut(Key.B, KeyModifier.Alt);
+            right = new Shortcut(Key.C, KeyModifier.Alt);
+
+            yield return
+                new TestCaseData(left, right);
+
+            left = new Shortcut(Key.M, KeyModifier.Alt | KeyModifier.Shift);
+            right = new Shortcut(Key.N, KeyModifier.Ctrl);
+
+            yield return
+                new TestCaseData(left, right);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(GetUnequalValues))]
+        public void Shortcut_Equals_ChecksInequality(object left, object right)
+        {
+            var result = left.Equals(right);
+
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        [TestCaseSource(nameof(GetUnequalValues))]
+        public void Shortcut_OpInequality_ChecksInequality(Shortcut left, Shortcut right)
+        {
+            var result = left != right;
+
+            result.Should().BeTrue();
+        }
+    }
+}

--- a/src/OFP.Library.Tests/Parser/ShortcutLIstenerTests.cs
+++ b/src/OFP.Library.Tests/Parser/ShortcutLIstenerTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using OFP.ObjectModel.Platform;
+using OFP.Parser;
+
+namespace OFP.Library.Tests.Parser
+{
+    /// <summary>
+    /// Тесты на <see cref="ShortcutListener"/>.
+    /// </summary>
+    [TestFixture]
+    internal class ShortcutLIstenerTests : ListenerTestFixture<ShortcutListener>
+    {
+        private static IEnumerable<TestCaseData> GetShortcutCases()
+        {
+            var input = "{0, 65, 0}";
+            var expected = new Shortcut(Key.A);
+
+            yield return
+                new TestCaseData(input, expected)
+                .SetArgDisplayNames("A");
+
+            input = "{0, 67, 8}";
+            expected = new Shortcut(Key.C, KeyModifier.Ctrl);
+
+            yield return
+                new TestCaseData(input, expected)
+                .SetArgDisplayNames("Ctrl+C");
+
+            input = "{0, 111, 24}";
+            expected = new Shortcut(Key.NumDivide, KeyModifier.Ctrl | KeyModifier.Alt);
+
+            yield return
+                new TestCaseData(input, expected)
+                .SetArgDisplayNames("Ctrl+Alt+/");
+
+            input = "{0, 32, 28}";
+            expected = new Shortcut(Key.Space, KeyModifier.Ctrl | KeyModifier.Alt | KeyModifier.Shift);
+
+            yield return
+                new TestCaseData(input, expected)
+                .SetArgDisplayNames("Ctrl+Alt+Shift+Space");
+        }
+
+        [Test]
+        [TestCaseSource(nameof(GetShortcutCases))]
+        public void ShortcutListener_Get_ReturnsParsedShortcut(string input, Shortcut expected)
+        {
+            var parser = CreateParser(input);
+            var tree = parser.shortcut();
+            WalkParseTree(tree);
+
+            var result = TestSubject.Get(tree);
+
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void ShortcutListener_Get_ThrowsWhenTreeDoesntHaveShortcut()
+        {
+            var parser = CreateParser("{}");
+            var tree = parser.emptyBlock();
+            WalkParseTree(tree);
+
+            Action action =
+                () => TestSubject.Get(tree);
+
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage($"Для узла дерева не найден элемент с типом {nameof(Shortcut)}.");
+        }
+    }
+}

--- a/src/OFP.Library/Parser/Generated/OrdinaryFormParser.cs
+++ b/src/OFP.Library/Parser/Generated/OrdinaryFormParser.cs
@@ -1586,6 +1586,8 @@ public partial class OrdinaryFormParser : Parser {
 	}
 
 	public partial class ShortcutContext : ParserRuleContext {
+		public IToken Key;
+		public IToken Modifier;
 		public ITerminalNode BLOCK_START() { return GetToken(OrdinaryFormParser.BLOCK_START, 0); }
 		public ITerminalNode[] NUMBER() { return GetTokens(OrdinaryFormParser.NUMBER); }
 		public ITerminalNode NUMBER(int i) {
@@ -1621,9 +1623,9 @@ public partial class OrdinaryFormParser : Parser {
 			State = 580; Match(BLOCK_START);
 			State = 581; Match(NUMBER);
 			State = 582; Match(VS);
-			State = 583; Match(NUMBER);
+			State = 583; _localctx.Key = Match(NUMBER);
 			State = 584; Match(VS);
-			State = 585; Match(NUMBER);
+			State = 585; _localctx.Modifier = Match(NUMBER);
 			State = 586; Match(BLOCK_END);
 			}
 		}

--- a/src/OFP.Library/Parser/ShortcutListener.cs
+++ b/src/OFP.Library/Parser/ShortcutListener.cs
@@ -1,0 +1,46 @@
+using System;
+using Antlr4.Runtime.Tree;
+using OFP.ObjectModel.Platform;
+using OFP.Parser.Annotations;
+using OFP.Parser.Generated;
+
+namespace OFP.Parser
+{
+    /// <summary>
+    /// Реализация разбора и хранения значений с типом <see cref="Shortcut"/>.
+    /// </summary>
+    internal class ShortcutListener : OrdinaryFormBaseListener, IValueCollector<Shortcut>
+    {
+        private readonly ParseTreeValue<Shortcut> _values =
+            new ParseTreeValue<Shortcut>();
+
+        private readonly ITokenCollector _tokens;
+
+        public ShortcutListener(ITokenCollector tokenCollector)
+        {
+            _tokens = tokenCollector;
+        }
+
+        public Shortcut Get(IParseTree node)
+        {
+            var value = _values.TryGet(node);
+            if (value == null)
+            {
+                throw new InvalidOperationException(
+                    $"Для узла дерева не найден элемент с типом {nameof(Shortcut)}.");
+            }
+
+            return (Shortcut)value;
+        }
+
+        public override void ExitShortcut(OrdinaryFormParser.ShortcutContext context)
+        {
+            var key = (Key)_tokens.GetNumber(context.Key);
+            var modifier = (KeyModifier)_tokens.GetNumber(context.Modifier);
+
+            var shortcut = new Shortcut(key, modifier);
+
+            _values.Put(context, shortcut);
+        }
+    }
+}


### PR DESCRIPTION
Еще добавил ToString к Shortcut, чтобы при отладке было видно сочетание клавиш.
И Equals чтобы правильно сравнивать значения с этим типом, так как без него .net делает упаковку значения.

Close #16.